### PR TITLE
Fix initalState typo

### DIFF
--- a/src/app/shared/title/+state/title.facade.ts
+++ b/src/app/shared/title/+state/title.facade.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { initalState, TitleState } from './title.model';
+import { initialState, TitleState } from './title.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class TitleFacade {
   private state$: BehaviorSubject<TitleState> = new BehaviorSubject<TitleState>(
-    initalState
+    initialState
   );
   title$: Observable<string> = this.state$.pipe(map(({ title }) => title));
 

--- a/src/app/shared/title/+state/title.model.ts
+++ b/src/app/shared/title/+state/title.model.ts
@@ -2,6 +2,6 @@ export interface TitleState {
   title: string;
 }
 
-export const initalState: TitleState = {
+export const initialState: TitleState = {
   title: '',
 };


### PR DESCRIPTION
## Summary
- fix typo in title model
- update TitleFacade to use the renamed `initialState`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865373cab0c8323b48a40946f31a0df