### PR TITLE
Update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+For a production build, use `ng build --configuration production`.
+The shorthand `ng build --prod` still works in some versions, but it is deprecated.
 
 ## Running unit tests
 


### PR DESCRIPTION
## Summary
- clarify production build instructions and mention that `--prod` is deprecated

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6867df356a308323b3c8697e16213d27